### PR TITLE
Make all ArrayAccess operators virtual (fails compilation)

### DIFF
--- a/src/array_class.h
+++ b/src/array_class.h
@@ -14,7 +14,7 @@ public:
    virtual double& operator[](int i) {
       return array[i];
    }
-	ArrayAccess operator+(int offset) {
+	virtual ArrayAccess operator+(int offset) {
 		return ArrayAccess(array + offset);
 	}
 };


### PR DESCRIPTION
This omission gave incorrect benchmark results _and_ incorrect actual
results. Not having tests _inside_ the benchmark sounds like a bad idea.

However, this doesn't compile as-is, because we try refining the return
type of the virtual function. I think this can be expressed, but it's
more complicated.

```
./src/functions/../array_class.h:33:21: error: virtual function 'operator+' has a different return type ('StridedArrayAccess') than the function it overrides
      (which has return type 'ArrayAccess')
        StridedArrayAccess operator+(int offset) {
        ~~~~~~~~~~~~~~~~~~ ^
./src/functions/../array_class.h:17:22: note: overridden virtual function is here
        virtual ArrayAccess operator+(int offset) {
                ~~~~~~~~~~~ ^
./src/functions/../array_class.h:49:26: error: virtual function 'operator+' has a different return type ('BlockStridedArrayAccess') than the function it overrides
      (which has return type 'StridedArrayAccess')
        BlockStridedArrayAccess operator+(int offset) {
        ~~~~~~~~~~~~~~~~~~~~~~~ ^
./src/functions/../array_class.h:33:21: note: overridden virtual function is here
        StridedArrayAccess operator+(int offset) {
        ~~~~~~~~~~~~~~~~~~ ^
```
